### PR TITLE
Add ability to use `16` in `pg_version`

### DIFF
--- a/internal/provider/resource_project.go
+++ b/internal/provider/resource_project.go
@@ -171,7 +171,7 @@ func (r *ProjectResource) Schema(ctx context.Context, req resource.SchemaRequest
 					int64planmodifier.RequiresReplace(),
 				},
 				Validators: []validator.Int64{
-					int64validator.OneOf(14, 15),
+					int64validator.OneOf(14, 15, 16),
 				},
 			},
 			"branch": schema.SingleNestedAttribute{


### PR DESCRIPTION
Add ability to use Postgres 16 in `pg_version` attribute. It should fix #7